### PR TITLE
implementing exponential backoff

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[cljs-web3-next "0.1.2"]
                  [com.taoensso/timbre "4.10.0"]
+                 [district0x/async-helpers "0.1.3"]
                  [district0x/district-server-config "1.0.1"]
                  [mount "0.1.16"]
                  [org.clojure/clojurescript "1.10.520"]]
@@ -12,8 +13,7 @@
   :npm {:dependencies [[web3 "1.2.0"]]
         :devDependencies [[ws "2.0.1"]]}
 
-  :profiles {:dev {:dependencies [[district0x/async-helpers "0.1.3"]
-                                  [org.clojure/clojure "1.10.1"]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.1"]
                                   [org.clojure/core.async "0.4.500"]]
                    :plugins [[lein-cljsbuild "1.1.7"]
                              [lein-npm "0.6.2"]

--- a/src/district/server/web3.cljs
+++ b/src/district/server/web3.cljs
@@ -3,12 +3,18 @@
             [cljs-web3-next.eth :as web3-eth]
             [cljs-web3-next.helpers :as web3-helpers]
             [clojure.string :as string]
+            [cljs.core.async :as async :refer [<! go go-loop]]
+            [district.shared.async-helpers :as async-helpers]
             [district.server.config :refer [config]]
             [mount.core :as mount :refer [defstate]]
             [taoensso.timbre :as log]))
 
+(async-helpers/extend-promises-as-channels!)
+
 (declare start)
 (declare stop)
+(declare ping-start)
+(declare ping-stop)
 
 (defonce ping (atom nil))
 
@@ -28,51 +34,65 @@
       (web3-core/websocket-provider uri {:client-config (merge {:max-received-frame-size 100000000
                                                                 :max-received-message-size 100000000}
                                                                client-config)})
-      (web3-core/http-provider uri))))
+      (throw (js/Error. "web3 component needs a websocket connection!")))))
 
-(defn- keep-alive [web3 interval]
+(defn- exponential-backoff
+  "Retries reconnection attempts to a web3 node exponentially, increasing the waiting time between retries up to a maximum backoff time of 32 seconds
+  after which every reconnection attempt is tried every 32 seconds + delta."
+  [{:keys [on-offline on-online web3-opts]}]
+  (let [maximum-backoff 32000
+        backoff-rate 2]
+    (on-offline)
+    (ping-stop)
+    (go-loop [backoff 1000]
+      (let [new-web3 (create web3-opts)
+            connected? (true? (<! (web3-eth/is-listening? new-web3)))]
+        (log/info "Polling..." {:connected? connected? :backoff backoff})
+        (if connected?
+          (do
+            (log/info "Reconnecting web3...")
+            ;; swap websocket
+            (web3-core/set-provider @web3 (web3-core/current-provider new-web3))
+            (on-online))
+          (do
+            (<! (async/timeout backoff))
+            (recur (if (>= backoff maximum-backoff)
+                       backoff
+                       (+ (* backoff backoff-rate) (rand-int 1000))))))))))
+
+(defn- keep-alive [interval]
   (js/setInterval
    (fn []
-     (cljs-web3-next.eth/is-listening? web3
-                                       (fn [error response]
-                                         (if-not error
-                                           (log/debug "ping" {:listening? response})
-                                           (log/error "ping" {:error error})))))
+     (go
+       (let [connected? (true? (<! (web3-eth/is-listening? @web3)))]
+         (if connected?
+           (log/debug "ping" {:connected? connected?})
+           (do
+             (log/warn "ping error" {:connected? connected?})
+             ;; NOTE: triggers exponential backoff
+             (web3-core/disconnect @web3))))))
    interval))
 
 (defn ping-start [{:keys [:ping-interval]
                    :or {ping-interval 10000}}]
-  (reset! ping (keep-alive @web3 ping-interval)))
+  (reset! ping (keep-alive ping-interval)))
 
 (defn ping-stop []
   (js/clearInterval @ping))
 
-(defn start [{:keys [:port :url :client-config :on-online :on-offline
-                     :reset-connection-poll-interval]
-              :or {reset-connection-poll-interval 3000}
+(defn start [{:keys [:port :url :client-config :on-online :on-offline]
               :as opts}]
-  (let [this-web3 (create opts)
-        interval-id (atom nil)
-        reset-connection (fn []
-                           (on-offline)
-                           (reset! interval-id (js/setInterval (fn []
-                                                                 (let [new-web3 (create opts)]
-                                                                   (web3-eth/is-listening? new-web3
-                                                                                           (fn [error result]
-                                                                                             (let [connected? (and (nil? error) result)]
-                                                                                               (log/debug "Polling..." {:connected? connected?})
-                                                                                               (when connected?
-                                                                                                 (js/clearInterval @interval-id)
-                                                                                                 ;; swap websocket
-                                                                                                 (web3-core/set-provider @web3 (web3-core/current-provider new-web3))
-                                                                                                 (on-online)))))))
-                                                               reset-connection-poll-interval)))]
+  (let [this-web3 (create opts)]
 
     (when (and (not port) (not url))
       (throw (js/Error. "You must provide port or url to start the web3 component")))
 
-    (web3-core/on-disconnect this-web3 reset-connection)
-    (web3-core/on-error this-web3 reset-connection)
+    (web3-core/on-disconnect this-web3 (fn []
+                                         (log/warn "web3 disconnected")
+                                         (exponential-backoff {:on-offline on-offline :on-online on-online :web3-opts opts})))
+    (web3-core/on-error this-web3 (fn [error]
+                                    (log/error "web3 error" {:error error})
+                                    (exponential-backoff {:on-offline on-offline :on-online on-online :web3-opts opts})))
 
     (web3-core/extend this-web3
       :evm
@@ -88,5 +108,5 @@
                              :call "evm_revert"})])))
 
 (defn stop [this]
-  (js/clearInterval @ping)
+  (ping-stop)
   (web3-core/disconnect @this))


### PR DESCRIPTION
This PR adds implements [exponential-backoff](https://cloud.google.com/iot/docs/how-tos/exponential-backoff#example_algorithm) to reconnect a web3 ethereum node client connection over a websocket. 