### PR TITLE
Makes sure there is no concurrent reconnections attempts

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x/district-server-web3 "1.2.6-SNAPSHOT"
+(defproject district0x/district-server-web3 "1.2.7-SNAPSHOT"
   :description "district0x server module for setting up web3"
   :url "https://github.com/district0x/district-server-web3"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
If websocket connection stops responding, there might be multiple issued "pings" until they realize the connection is gone, after which they all come together. Once those pings returns, they all call exponential-backoff, and starts multiple parallel independent backoff retries, which might both exhaust the websocket and call "on-online" multiple times when/if the websocket connection resumes.

This PR ensures only one concurrent backoff retry attempt is being executed at once.